### PR TITLE
UX fixes

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -19,8 +19,10 @@
   <body>
     <main>
       <h1>Example typeahead</h1>
-      <label for="typeahead">Select your country</label>
-      <div id="tt"></div>
+      <form method="POST" action="/basic.html">
+        <label for="typeahead">Select your country</label>
+        <div id="tt"></div>
+      </form>
     </main>
 
     <script type="text/javascript" src="../dist/accessible-typeahead.min.js"></script>

--- a/examples/styled.html
+++ b/examples/styled.html
@@ -81,7 +81,7 @@
         border-top-width: 0;
       }
 
-      .tt-suggestion:hover, .tt-suggestion:focus {
+      .tt-suggestion:focus {
         z-index: 1;
         background-color: #2b8cc4;
         border-color: #2b8cc4;

--- a/examples/styled.html
+++ b/examples/styled.html
@@ -52,6 +52,7 @@
         list-style: none;
         background-color: #fff;
         border: 2px solid #6f777b;
+        border-top: 0;
       }
 
       .tt-suggestion {

--- a/examples/styled.html
+++ b/examples/styled.html
@@ -86,6 +86,7 @@
         background-color: #2b8cc4;
         border-color: #2b8cc4;
         color: white;
+        outline: none;
       }
 
       @media (min-width: 641px) {

--- a/examples/styled.html
+++ b/examples/styled.html
@@ -59,11 +59,10 @@
         position: relative;
         display: block;
         margin-bottom: -2px;
-        padding: 8px;
+        padding: 5px 4px 4px;
         border: solid #bfc1c3;
         border-width: 2px 0;
         font-family: "nta", Arial, sans-serif;
-        font-weight: 700;
         text-transform: none;
         font-size: 16px;
         line-height: 1.25;

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -108,6 +108,13 @@ export default class Typeahead extends Component {
   }
 
   handleOptionSelect (evt, idx = this.state.selected) {
+    if (this.props.autoselect) {
+      const inputSelected = idx === -1
+      if (inputSelected) {
+        idx = 0
+      }
+    }
+
     this.setState({
       menuOpen: false,
       query: this.state.options[idx],
@@ -137,7 +144,10 @@ export default class Typeahead extends Component {
 
   handleEnter (evt) {
     evt.preventDefault()
-    this.handleOptionSelect(evt)
+
+    if (this.state.menuOpen) {
+      this.handleOptionSelect(evt)
+    }
   }
 
   handleKeyDown (evt) {

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -25,6 +25,7 @@ export default class Typeahead extends Component {
     this.handleKeyDown = this.handleKeyDown.bind(this)
     this.handleUpArrow = this.handleUpArrow.bind(this)
     this.handleDownArrow = this.handleDownArrow.bind(this)
+    this.handleEnter = this.handleEnter.bind(this)
 
     this.handleOptionBlur = this.handleOptionBlur.bind(this)
     this.handleOptionFocus = this.handleOptionFocus.bind(this)
@@ -131,6 +132,11 @@ export default class Typeahead extends Component {
     }
   }
 
+  handleEnter (evt) {
+    evt.preventDefault()
+    this.handleOptionSelect(evt)
+  }
+
   handleKeyDown (evt) {
     switch (kc[evt.keyCode]) {
       case 'up':
@@ -140,7 +146,7 @@ export default class Typeahead extends Component {
         this.handleDownArrow(evt)
         break
       case 'enter':
-        this.handleOptionSelect(evt)
+        this.handleEnter(evt)
         break
       case 'escape':
         this.handleComponentBlur(evt)

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -45,7 +45,10 @@ export default class Typeahead extends Component {
     const searchForOptions = !queryEmpty && queryChanged
     if (searchForOptions) {
       source(query, (options) => {
-        this.setState({ options })
+        this.setState({
+          menuOpen: options.length > 0,
+          options
+        })
       })
     }
 

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -219,7 +219,7 @@ export default class Typeahead extends Component {
         id={`${id}__option--${idx}`}
         onBlur={(evt) => this.handleOptionBlur(evt, idx)}
         onClick={(evt) => this.handleOptionSelect(evt, idx)}
-        onMouseOver={() => this.handleOptionFocus(idx)}
+        onMouseMove={() => this.handleOptionFocus(idx)}
         role='option'
         tabindex='-1'
       >

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -71,9 +71,9 @@ export default class Typeahead extends Component {
     const { selected } = this.state
     // Safari triggers blur before click, so check if the target of the blur
     // is the currently hovered/focused element.
-    const clickingOnTheSelectedOption = evt.target === elementRefs[selected]
+    const focusingOutsideComponent = evt.relatedTarget === null
     const selectingAnotherOption = selected !== idx
-    if (!selectingAnotherOption && !clickingOnTheSelectedOption) {
+    if (focusingOutsideComponent || !selectingAnotherOption) {
       this.handleComponentBlur()
     }
   }

--- a/test/browser/index.jsx
+++ b/test/browser/index.jsx
@@ -59,7 +59,17 @@ describe('Typeahead', () => {
         const previousState = {...typeahead.state}
         typeahead.handleInputChange({ target: { value: 'f' } })
         typeahead.componentDidUpdate(previousProps, previousState)
+        expect(typeahead.state.menuOpen).to.equal(true)
         expect(typeahead.state.options).to.contain('France')
+      })
+
+      it('hides menu when no options are available', () => {
+        const previousProps = {...typeahead.props}
+        const previousState = {...typeahead.state}
+        typeahead.handleInputChange({ target: { value: 'aa' } })
+        typeahead.componentDidUpdate(previousProps, previousState)
+        expect(typeahead.state.menuOpen).to.equal(false)
+        expect(typeahead.state.options.length).to.equal(0)
       })
     })
 


### PR DESCRIPTION
- `preventDefault` on enter, to avoid submitting forms (add a form around the basic example to test this)
- Don't display an empty menu when there are no options
- Styled example tweaks: remove focus outline on options, remove top border from menu, unbold results, make height of options consistent with input
- Close results when focusing outside of component
- (WIP) Make enter select first option if input selected, hidden behind `autoselect` prop
- Only apply the focus class when the element is focused, remove hover styling
