### PR TITLE
Changes to styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 _(add items here for easier creation of next log entry)_
 
+- Allow importing styling from file in `examples/styled.css`.
+- Change the CSS classes to our own instead of the jQuery typeahead ones.
+- Tweak the styled example to fix two Safari bugs:
+  - fix scroll bar appearing in menu where none is necessary;
+  - fix weird margin separating the input from the menu.
+
 ## 0.1.3 - 2017-01-31
 
 - Don't apply focused CSS on hover, change handler to MouseOver instead of MouseMove.

--- a/examples/styled.css
+++ b/examples/styled.css
@@ -5,7 +5,6 @@
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
-  padding: 4px;
   width: 100%;
 }
 
@@ -29,7 +28,6 @@
   border-width: 1px 0;
   cursor: pointer;
   display: block;
-  padding: 4px;
   position: relative;
 }
 
@@ -47,4 +45,19 @@
   color: white;
   outline: none;
   z-index: 1;
+}
+
+.typeahead__input,
+.typeahead__option {
+  font-size: 16px;
+  line-height: 1.25;
+  padding: 4px;
+}
+
+@media (min-width: 641px) {
+  .typeahead__input,
+  .typeahead__option {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
 }

--- a/examples/styled.css
+++ b/examples/styled.css
@@ -16,6 +16,7 @@
 
 .typeahead__menu {
   border: 2px solid #6f777b;
+  border-top: 0;
   margin: 0;
   max-height: 342px;
   overflow-x: hidden;

--- a/examples/styled.css
+++ b/examples/styled.css
@@ -1,5 +1,5 @@
 /* Typeahead styling. */
-.form-control {
+.typeahead__input {
   -webkit-appearance: none;
   border: 2px solid;
   box-sizing: border-box;
@@ -9,12 +9,12 @@
   width: 100%;
 }
 
-.form-control:focus {
+.typeahead__input:focus {
   outline-offset: 0;
   outline: 3px solid #ffbf47;
 }
 
-.tt-menu {
+.typeahead__menu {
   border: 2px solid #6f777b;
   margin: 0;
   max-height: 342px;
@@ -24,7 +24,7 @@
   width: calc(100% - 4px);
 }
 
-.tt-suggestion {
+.typeahead__option {
   border: solid #bfc1c3;
   border-width: 1px 0;
   cursor: pointer;
@@ -33,15 +33,15 @@
   position: relative;
 }
 
-.tt-suggestion:first-of-type {
+.typeahead__option:first-of-type {
   border-top-width: 0;
 }
 
-.tt-suggestion:last-of-type {
+.typeahead__option:last-of-type {
   border-bottom-width: 0;
 }
 
-.tt-suggestion:focus {
+.typeahead__option:focus {
   background-color: #2b8cc4;
   border-color: #2b8cc4;
   color: white;

--- a/examples/styled.css
+++ b/examples/styled.css
@@ -1,0 +1,50 @@
+/* Typeahead styling. */
+.form-control {
+  -webkit-appearance: none;
+  border: 2px solid;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  padding: 4px;
+  width: 100%;
+}
+
+.form-control:focus {
+  outline-offset: 0;
+  outline: 3px solid #ffbf47;
+}
+
+.tt-menu {
+  border: 2px solid #6f777b;
+  margin: 0;
+  max-height: 342px;
+  overflow-x: hidden;
+  padding: 0;
+  width: 100%;
+  width: calc(100% - 4px);
+}
+
+.tt-suggestion {
+  border: solid #bfc1c3;
+  border-width: 1px 0;
+  cursor: pointer;
+  display: block;
+  padding: 4px;
+  position: relative;
+}
+
+.tt-suggestion:first-of-type {
+  border-top-width: 0;
+}
+
+.tt-suggestion:last-of-type {
+  border-bottom-width: 0;
+}
+
+.tt-suggestion:focus {
+  background-color: #2b8cc4;
+  border-color: #2b8cc4;
+  color: white;
+  outline: none;
+  z-index: 1;
+}

--- a/examples/styled.css
+++ b/examples/styled.css
@@ -5,6 +5,7 @@
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
+  margin-bottom: 0; /* BUG: Safari 10 seems to add an implicit margin. */
   width: 100%;
 }
 

--- a/examples/styled.html
+++ b/examples/styled.html
@@ -14,6 +14,13 @@
         margin: 0 auto;
         max-width: 600px;
       }
+
+
+      @media (min-width: 641px) {
+        .typeahead-wrapper {
+          width: 50%
+        }
+      }
     </style>
     <link rel="stylesheet" href="styled.css">
   </head>
@@ -22,7 +29,7 @@
     <main>
       <h1>Example typeahead</h1>
       <label for="typeahead">Select your country</label>
-      <div id="tt"></div>
+      <div id="tt" class="typeahead-wrapper"></div>
     </main>
 
     <script type="text/javascript" src="../dist/accessible-typeahead.min.js"></script>

--- a/examples/styled.html
+++ b/examples/styled.html
@@ -15,87 +15,9 @@
         max-width: 600px;
       }
     </style>
+    <link rel="stylesheet" href="styled.css">
   </head>
   <body>
-    <style>
-      /* Typeahead styling. */
-      .form-control {
-        -webkit-appearance: none;
-        background-color: transparent;
-        border-radius: 0;
-        border: 2px solid;
-        box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        -webkit-box-sizing: border-box;
-        color: inherit;
-        font-family: Arial, sans-serif;
-        font-size: 19px;
-        font-weight: 400;
-        line-height: 1.31579;
-        padding: 5px 4px 4px;
-        text-transform: none;
-        width: 50%;
-      }
-
-      input:focus {
-        outline: 3px solid #ffbf47;
-        outline-offset: 0;
-      }
-
-      .tt-menu {
-        width: 100%;
-        width: calc(100% - 4px);
-        max-height: 342px;
-        overflow-x: hidden;
-        margin: 0;
-        padding: 0;
-        list-style: none;
-        background-color: #fff;
-        border: 2px solid #6f777b;
-        border-top: 0;
-      }
-
-      .tt-suggestion {
-        position: relative;
-        display: block;
-        margin-bottom: -2px;
-        padding: 5px 4px 4px;
-        border: solid #bfc1c3;
-        border-width: 2px 0;
-        font-family: "nta", Arial, sans-serif;
-        text-transform: none;
-        font-size: 16px;
-        line-height: 1.25;
-        color: #0b0c0c;
-        cursor: pointer;
-      }
-
-      @media (min-width: 641px) {
-        .tt-suggestion {
-          font-size: 19px;
-          line-height: 1.31579;
-        }
-      }
-
-      .tt-suggestion:first-of-type {
-        border-top-width: 0;
-      }
-
-      .tt-suggestion:focus {
-        z-index: 1;
-        background-color: #2b8cc4;
-        border-color: #2b8cc4;
-        color: white;
-        outline: none;
-      }
-
-      @media (min-width: 641px) {
-        .tt-menu {
-          width: 50%;
-          width: calc(50% - 4px);
-        }
-      }
-    </style>
 
     <main>
       <h1>Example typeahead</h1>

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -170,7 +170,7 @@ export default class Typeahead extends Component {
   }
 
   render () {
-    const { id = 'typeahead' } = this.props
+    const { id = 'typeahead', cssNamespace = 'typeahead' } = this.props
     const { menuOpen, options, query, selected } = this.state
 
     const Wrapper = ({ children }) =>
@@ -186,7 +186,7 @@ export default class Typeahead extends Component {
         aria-activedescendant={selected !== -1 ? `${id}__option--${selected}` : ''}
         aria-expanded={options.length > 0}
         aria-owns={`${id}__listbox`}
-        className='form-control'
+        className={`${cssNamespace}__input`}
         id={id}
         onBlur={this.handleInputBlur}
         onFocus={this.handleInputFocus}
@@ -199,7 +199,7 @@ export default class Typeahead extends Component {
 
     const Menu = ({ children }) =>
       <ul
-        className='tt-menu'
+        className={`${cssNamespace}__menu`}
         id={`${id}__listbox`}
         role='listbox'
         style={{
@@ -215,7 +215,7 @@ export default class Typeahead extends Component {
 
     const Option = ({ children, idx }) =>
       <li
-        className='tt-suggestion'
+        className={`${cssNamespace}__option`}
         id={`${id}__option--${idx}`}
         onBlur={(evt) => this.handleOptionBlur(evt, idx)}
         onClick={(evt) => this.handleOptionSelect(evt, idx)}


### PR DESCRIPTION
- Provide `styled.css` as a separate file, which can also be included by other projects.
- Use our own classes for now instead of the jQuery typeahead ones. We will add these back in once we create a proper shim for it.
- Tweak the styling to fix two Safari bugs: a scroll bar appearing where none is necessary, and a weird margin separating the input from the menu.