### PR TITLE
Add ability to specify name attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 _(add items here for easier creation of next log entry)_
 
+- Add ability to set `name` attribute on input.
+
 ## 0.2.0 - 2017-01-31
 
 - [Breaking] Change the CSS classes to our own instead of the jQuery typeahead ones.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ The container element in which the typeahead will be rendered in.
 
 The `id` for the typeahead input field, to use with a `<label for=id>`. Required if you're instantiating more than one typeahead in one page.
 
+### `name: String` (optional, default: `'input-typeahead'`)
+
+The `name` for the typeahead input field, to use with a parent `<form>`.
+
 ### `source: Function`
 
 Arguments: `query: string, syncResults: Function`

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -170,7 +170,7 @@ export default class Typeahead extends Component {
   }
 
   render () {
-    const { id = 'typeahead', cssNamespace = 'typeahead' } = this.props
+    const { id = 'typeahead', cssNamespace = 'typeahead', name = 'input-typeahead' } = this.props
     const { menuOpen, options, query, selected } = this.state
 
     const Wrapper = ({ children }) =>
@@ -188,6 +188,7 @@ export default class Typeahead extends Component {
         aria-owns={`${id}__listbox`}
         className={`${cssNamespace}__input`}
         id={id}
+        name={name}
         onBlur={this.handleInputBlur}
         onFocus={this.handleInputFocus}
         onInput={this.handleInputChange}

--- a/src/wrapper.jsx
+++ b/src/wrapper.jsx
@@ -6,12 +6,14 @@ if (window) {
     cssNamespace,
     element,
     id,
+    name,
     source
   }) {
     render(
       <Typeahead
         cssNamespace={cssNamespace}
         id={id}
+        name={name}
         source={source}
       />,
       element

--- a/test/browser/index.jsx
+++ b/test/browser/index.jsx
@@ -40,6 +40,12 @@ describe('Typeahead', () => {
 
         expect(scratch.innerHTML).to.contain('input')
       })
+
+      it('renders an input with a name attribute', () => {
+        render(<Typeahead name='bob' />, scratch)
+
+        expect(scratch.innerHTML).to.contain('name="bob"')
+      })
     })
   })
 


### PR DESCRIPTION
This allows using the typeahead with an actual HTML form.