### PR TITLE
Don't close the menu when blurring keyboard on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 _(add items here for easier creation of next log entry)_
 
+- Don't close menu when closing the keyboard on iOS, to allow VoiceOver users the ability to select from the available options.
 - Add ability to set `name` attribute on input.
 
 ## 0.2.0 - 2017-01-31

--- a/test/browser/index.jsx
+++ b/test/browser/index.jsx
@@ -80,10 +80,10 @@ describe('Typeahead', () => {
     })
 
     describe('focusing input', () => {
-      it('displays menu when something is typed in', () => {
+      it('does not display menu when something is typed in', () => {
         typeahead.setState({ query: 'f' })
         typeahead.handleInputFocus()
-        expect(typeahead.state.menuOpen).to.equal(true)
+        expect(typeahead.state.menuOpen).to.equal(false)
         expect(typeahead.state.selected).to.equal(-1)
       })
 
@@ -98,7 +98,7 @@ describe('Typeahead', () => {
     describe('blurring input', () => {
       it('unfocuses component', () => {
         typeahead.setState({ menuOpen: true, options: ['France'], selected: -1 })
-        typeahead.handleInputBlur()
+        typeahead.handleInputBlur({ relatedTarget: null })
         expect(typeahead.state.menuOpen).to.equal(false)
         expect(typeahead.state.selected).to.equal(null)
       })


### PR DESCRIPTION
This allows VoiceOver users the ability to more easily select from available options.