### PR TITLE
Close the menu when the query becomes empty

### DIFF
--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -96,6 +96,8 @@ export default class Typeahead extends Component {
           options
         })
       })
+    } else if (queryEmpty) {
+      this.setState({ menuOpen: false })
     }
   }
 

--- a/test/browser/index.jsx
+++ b/test/browser/index.jsx
@@ -61,19 +61,13 @@ describe('Typeahead', () => {
 
     describe('typing', () => {
       it('searches for options', () => {
-        const previousProps = {...typeahead.props}
-        const previousState = {...typeahead.state}
         typeahead.handleInputChange({ target: { value: 'f' } })
-        typeahead.componentDidUpdate(previousProps, previousState)
         expect(typeahead.state.menuOpen).to.equal(true)
         expect(typeahead.state.options).to.contain('France')
       })
 
       it('hides menu when no options are available', () => {
-        const previousProps = {...typeahead.props}
-        const previousState = {...typeahead.state}
         typeahead.handleInputChange({ target: { value: 'aa' } })
-        typeahead.componentDidUpdate(previousProps, previousState)
         expect(typeahead.state.menuOpen).to.equal(false)
         expect(typeahead.state.options.length).to.equal(0)
       })

--- a/test/browser/index.jsx
+++ b/test/browser/index.jsx
@@ -71,6 +71,12 @@ describe('Typeahead', () => {
         expect(typeahead.state.menuOpen).to.equal(false)
         expect(typeahead.state.options.length).to.equal(0)
       })
+
+      it('hides menu when query becomes empty', () => {
+        typeahead.setState({ query: 'f', options: ['France'], menuOpen: true })
+        typeahead.handleInputChange({ target: { value: '' } })
+        expect(typeahead.state.menuOpen).to.equal(false)
+      })
     })
 
     describe('focusing input', () => {


### PR DESCRIPTION
This was introduced in #5.

Also clean up some unnecessary lines from a few tests.