### PR TITLE
Remove border-radius on iOS in styled version

### DIFF
--- a/examples/styled.css
+++ b/examples/styled.css
@@ -2,10 +2,11 @@
 .typeahead__input {
   -webkit-appearance: none;
   border: 2px solid;
+  border-radius: 0; /* Safari 10 on iOS adds implicit border rounding. */
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
-  margin-bottom: 0; /* BUG: Safari 10 seems to add an implicit margin. */
+  margin-bottom: 0; /* BUG: Safari 10 on macOS seems to add an implicit margin. */
   width: 100%;
 }
 


### PR DESCRIPTION
This was introduced by accident when I refactored the CSS.

## Before
![img_0486](https://cloud.githubusercontent.com/assets/1650875/22587148/5e96b512-e9f8-11e6-87c0-79d46ab0a42d.jpg)

## After
![img_0487](https://cloud.githubusercontent.com/assets/1650875/22587149/5e993fb2-e9f8-11e6-9852-31897d27b043.jpg)
