### PR TITLE
Select text only when unfocused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 _(add items here for easier creation of next log entry)_
 
+- Select text only when component is unfocused.
+
 ## 0.2.2 - 2017-02-16
 
 - Fix focus/blur events on IE11.

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -50,7 +50,8 @@ export default class Typeahead extends Component {
       elementRefs[selected].focus()
     }
     const focusedInput = selected === -1
-    const selectAll = selectedChanged && focusedInput
+    const componentGainedFocus = selectedChanged && prevState.selected === null
+    const selectAll = focusedInput && componentGainedFocus
     if (selectAll) {
       const inputEl = elementRefs[-1]
       inputEl.setSelectionRange(0, inputEl.value.length)


### PR DESCRIPTION
This will prevent selecting the text when arrowing out of the options.