### PR TITLE
No options content

### DIFF
--- a/examples/styled.css
+++ b/examples/styled.css
@@ -20,8 +20,8 @@
 }
 
 .typeahead__hint {
-  position: absolute;
   color: #BFC1C3;
+  position: absolute;
 }
 
 .typeahead__input:focus {
@@ -90,6 +90,8 @@
 }
 
 .typeahead__option--no-results {
+  background-color: #FAFAFA;
+  color: #646b6f;
   cursor: not-allowed;
 }
 

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -302,7 +302,7 @@ export default class Typeahead extends Component {
       <li
         className={`${cssNamespace}__option ${cssNamespace}__option--no-results`}
       >
-        No options found.
+        No results found
       </li>
 
     const Option = ({ children, idx }) => {


### PR DESCRIPTION
Update content and styling for "no options found"

Before:
![screen shot 2017-03-09 at 12 25 13](https://cloud.githubusercontent.com/assets/2204224/23750155/839acc50-04c3-11e7-9ebc-bac682a0b37b.png)

After:
![screen shot 2017-03-09 at 12 24 59](https://cloud.githubusercontent.com/assets/2204224/23750148/8029b9aa-04c3-11e7-8225-ae7f97bd3b6c.png)

@tvararu ideally this content would be configurable.
