### PR TITLE
Multiple fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 _(add items here for easier creation of next log entry)_
 
 - Add ability to specify a `defaultValue` to prefill the input.
+- When user has selected an option with the keyboard, blurring will select.
+- When user has no selected but autoselect is on, blurring will select.
+- Hovering no longer selects, just focuses.
+- When hovering out of component, focus returns to selected.
+- Allow enter to submit forms when menu isn't opened.
+- Hide results when going under minLength.
 
 ## 0.3.0 - 2017-03-09
 

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -244,11 +244,12 @@ export default class Typeahead extends Component {
   }
 
   handleEnter (evt) {
-    evt.preventDefault()
-    const hasSelectedOption = this.state.selected >= 0
-
-    if (this.state.menuOpen && hasSelectedOption) {
-      this.handleOptionClick(evt, this.state.selected)
+    if (this.state.menuOpen) {
+      evt.preventDefault()
+      const hasSelectedOption = this.state.selected >= 0
+      if (hasSelectedOption) {
+        this.handleOptionClick(evt, this.state.selected)
+      }
     }
   }
 

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -163,7 +163,7 @@ export default class Typeahead extends Component {
           selected: (autoselect && optionsAvailable) ? 0 : -1
         })
       })
-    } else if (queryEmpty) {
+    } else if (queryEmpty || !queryLongEnough) {
       this.setState({
         menuOpen: false,
         options: []

--- a/test/browser/index.jsx
+++ b/test/browser/index.jsx
@@ -135,6 +135,16 @@ describe('Typeahead', () => {
         expect(typeahead.state.focused).to.equal(-1)
       })
 
+      describe('with option selected', () => {
+        it('leaves menu open, does not change query', () => {
+          typeahead.setState({ menuOpen: true, options: ['France'], query: 'fr', focused: 0, selected: 0 })
+          typeahead.handleInputFocus()
+          expect(typeahead.state.focused).to.equal(-1)
+          expect(typeahead.state.menuOpen).to.equal(true)
+          expect(typeahead.state.query).to.equal('fr')
+        })
+      })
+
       describe('with defaultValue', () => {
         beforeEach(() => {
           typeahead = new Typeahead({
@@ -155,10 +165,21 @@ describe('Typeahead', () => {
 
     describe('blurring input', () => {
       it('unfocuses component', () => {
-        typeahead.setState({ menuOpen: true, options: ['France'], focused: -1 })
+        typeahead.setState({ menuOpen: true, options: ['France'], query: 'fr', focused: -1, selected: -1 })
         typeahead.handleInputBlur({ relatedTarget: null })
-        expect(typeahead.state.menuOpen).to.equal(false)
         expect(typeahead.state.focused).to.equal(null)
+        expect(typeahead.state.menuOpen).to.equal(false)
+        expect(typeahead.state.query).to.equal('fr')
+      })
+
+      describe('autoselect', () => {
+        it('unfocuses component, updates query', () => {
+          autoselectTypeahead.setState({ menuOpen: true, options: ['France'], query: 'fr', focused: -1, selected: 0 })
+          autoselectTypeahead.handleInputBlur({ target: 'mock', relatedTarget: 'relatedMock' }, 0)
+          expect(autoselectTypeahead.state.focused).to.equal(null)
+          expect(autoselectTypeahead.state.menuOpen).to.equal(false)
+          expect(autoselectTypeahead.state.query).to.equal('France')
+        })
       })
     })
 
@@ -171,11 +192,42 @@ describe('Typeahead', () => {
     })
 
     describe('focusing out option', () => {
-      it('unfocuses component', () => {
-        typeahead.setState({ menuOpen: true, options: ['France'], focused: 0 })
-        typeahead.handleOptionFocusOut({ target: 'mock' }, 0)
-        expect(typeahead.state.menuOpen).to.equal(false)
-        expect(typeahead.state.focused).to.equal(null)
+      describe('with input selected', () => {
+        it('unfocuses component, does not change query', () => {
+          typeahead.setState({ menuOpen: true, options: ['France'], query: 'fr', focused: 0, selected: -1 })
+          typeahead.handleOptionFocusOut({ target: 'mock', relatedTarget: 'relatedMock' }, 0)
+          expect(typeahead.state.focused).to.equal(null)
+          expect(typeahead.state.menuOpen).to.equal(false)
+          expect(typeahead.state.query).to.equal('fr')
+        })
+      })
+
+      describe('with option selected', () => {
+        it('unfocuses component, updates query', () => {
+          typeahead.setState({ menuOpen: true, options: ['France'], query: 'fr', focused: 0, selected: 0 })
+          typeahead.handleOptionFocusOut({ target: 'mock', relatedTarget: 'relatedMock' }, 0)
+          expect(typeahead.state.focused).to.equal(null)
+          expect(typeahead.state.menuOpen).to.equal(false)
+          expect(typeahead.state.query).to.equal('France')
+        })
+      })
+    })
+
+    describe('hovering option', () => {
+      it('sets the option as focused, does not change selected', () => {
+        typeahead.setState({ options: ['France'], focused: -1, selected: -1 })
+        typeahead.handleOptionMouseMove(0)
+        expect(typeahead.state.focused).to.equal(0)
+        expect(typeahead.state.selected).to.equal(-1)
+      })
+    })
+
+    describe('hovering out option', () => {
+      it('sets focus back on selected', () => {
+        typeahead.setState({ options: ['France'], focused: 0, selected: -1 })
+        typeahead.handleOptionMouseOut({ toElement: 'mock' }, 0)
+        expect(typeahead.state.focused).to.equal(-1)
+        expect(typeahead.state.selected).to.equal(-1)
       })
     })
 

--- a/test/browser/index.jsx
+++ b/test/browser/index.jsx
@@ -117,6 +117,13 @@ describe('Typeahead', () => {
           expect(typeahead.state.menuOpen).to.equal(true)
           expect(typeahead.state.options).to.contain('France')
         })
+
+        it('hides results when going under limit', () => {
+          typeahead.setState({ menuOpen: true, query: 'fr', options: ['France'] })
+          typeahead.handleInputChange({ target: { value: 'f' } })
+          expect(typeahead.state.menuOpen).to.equal(false)
+          expect(typeahead.state.options.length).to.equal(0)
+        })
       })
     })
 

--- a/test/browser/index.jsx
+++ b/test/browser/index.jsx
@@ -308,22 +308,39 @@ describe('Typeahead', () => {
 
     describe('enter key', () => {
       describe('on an option', () => {
-        it('closes the menu, sets the query, focuses the input', () => {
+        it('prevents default, closes the menu, sets the query, focuses the input', () => {
+          let preventedDefault = false
           typeahead.setState({ menuOpen: true, options: ['France'], focused: 0, selected: 0 })
-          typeahead.handleKeyDown({ preventDefault: () => {}, keyCode: 13 })
+          typeahead.handleKeyDown({ preventDefault: () => { preventedDefault = true }, keyCode: 13 })
           expect(typeahead.state.menuOpen).to.equal(false)
           expect(typeahead.state.query).to.equal('France')
           expect(typeahead.state.focused).to.equal(-1)
           expect(typeahead.state.selected).to.equal(-1)
+          expect(preventedDefault).to.equal(true)
         })
       })
 
       describe('on the input', () => {
-        it('does nothing', () => {
-          typeahead.setState({ menuOpen: true, options: ['France'], focused: -1, selected: -1 })
-          const stateBefore = typeahead.state
-          typeahead.handleKeyDown({ preventDefault: () => {}, keyCode: 13 })
-          expect(typeahead.state).to.equal(stateBefore)
+        describe('with menu opened', () => {
+          it('prevents default, does nothing', () => {
+            let preventedDefault = false
+            typeahead.setState({ menuOpen: true, options: [], query: 'asd', focused: -1, selected: -1 })
+            const stateBefore = typeahead.state
+            typeahead.handleKeyDown({ preventDefault: () => { preventedDefault = true }, keyCode: 13 })
+            expect(typeahead.state).to.equal(stateBefore)
+            expect(preventedDefault).to.equal(true)
+          })
+        })
+
+        describe('with menu closed', () => {
+          it('bubbles, does not prevent default', () => {
+            let preventedDefault = false
+            typeahead.setState({ menuOpen: false, options: ['France'], focused: -1, selected: -1 })
+            const stateBefore = typeahead.state
+            typeahead.handleKeyDown({ preventDefault: () => { preventedDefault = true }, keyCode: 13 })
+            expect(typeahead.state).to.equal(stateBefore)
+            expect(preventedDefault).to.equal(false)
+          })
         })
 
         describe('autoselect', () => {


### PR DESCRIPTION
- When user has selected an option with the keyboard, blur will select
- When user has no selected but autoselect is on, blur will select
- Hovering no longer selects, just focuses
- When hovering out of component, focus returns to selected
- Allow enter to submit forms when menu isn't opened
- Hide results when going under minLength