### PR TITLE
Fix minor syntax error in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ function suggest (query, syncResults) {
 }
 
 AccessibleTypeahead({
-  element: document.querySelector('#my-typeahead-container')
+  element: document.querySelector('#my-typeahead-container'),
   id: 'my-typeahead',
   source: suggest
 })


### PR DESCRIPTION
There should be a comma between the element and id object fields.