### PR TITLE
Add `enhanceSelectElement` function and `onSelect` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 _(add items here for easier creation of next log entry)_
 
+- Add `AccessibleTypeahead.enhanceSelectElement` function.
+- Add `onSelect` property.
+
 ## 0.3.1 - 2017-03-09
 
 - Add ability to specify a `defaultValue` to prefill the input.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ The minimum number of characters that should be entered before the typeahead wil
 
 The `name` for the typeahead input field, to use with a parent `<form>`.
 
+#### `onSelect: Function` (default: `() => {}`)
+
+Arguments: `query: string`
+
+This function will be called when the user selects an option, with the option they've selected.
+
 ## Progressive enhancement
 
 If your typeahead is meant to select from a small list of options (a few hundreds), we strongly suggest that you render a `<select>` menu on the server, and use progressive enhancement.

--- a/README.md
+++ b/README.md
@@ -56,41 +56,13 @@ AccessibleTypeahead({
 
 > :warning: WARNING: This is a work in progress and will change significantly. :warning:
 
-### `autoselect: boolean` (optional, default: `false`)
+### Required options
 
-Set to true to highlight the first option when the user types in something and receives results. Pressing enter will select it.
-
-### `cssNamespace: String` (optional, default: `'typeahead'`)
-
-The default CSS classes use [BEM](http://getbem.com/) with `typeahead` as the block name. If you already have CSS rules for `.typeahead--menu` or any of the other default classes, you can use this property to rename them and prevent clashes.
-
-TODO: Better styling docs.
-
-### `defaultValue: String` (optional)
-
-Specify a string to prefill the typeahead with.
-
-### `displayMenu: String` (optional, default: `'inline'`, possible values: `oneOf(['inline', 'overlay']`)
-
-You can set this property to specify the way the menu should appear, whether inline or as an overlay.
-
-### `element: HTMLElement`
+#### `element: HTMLElement`
 
 The container element in which the typeahead will be rendered in.
 
-### `id: String` (optional, default: `'typeahead'`)
-
-The `id` for the typeahead input field, to use with a `<label for=id>`. Required if you're instantiating more than one typeahead in one page.
-
-### `minLength: Number` (optional, default: `0`)
-
-The minimum number of characters that should be entered before the typeahead will attempt to suggest options. When the query length is under this, the aria status region will also provide helpful text to the user informing them they should type in more.
-
-### `name: String` (optional, default: `'input-typeahead'`)
-
-The `name` for the typeahead input field, to use with a parent `<form>`.
-
-### `source: Function`
+#### `source: Function`
 
 Arguments: `query: string, syncResults: Function`
 
@@ -113,6 +85,78 @@ function suggest (query, syncResults) {
   )
 }
 ```
+
+### Other options
+
+#### `autoselect: boolean` (default: `false`)
+
+Set to true to highlight the first option when the user types in something and receives results. Pressing enter will select it.
+
+#### `cssNamespace: String` (default: `'typeahead'`)
+
+The default CSS classes use [BEM](http://getbem.com/) with `typeahead` as the block name. If you already have CSS rules for `.typeahead--menu` or any of the other default classes, you can use this property to rename them and prevent clashes.
+
+TODO: Better styling docs.
+
+#### `defaultValue: String` (default: `''`)
+
+Specify a string to prefill the typeahead with.
+
+#### `displayMenu: String` (default: `'inline'`, possible values: `oneOf(['inline', 'overlay']`)
+
+You can set this property to specify the way the menu should appear, whether inline or as an overlay.
+
+#### `id: String` (default: `'typeahead'`)
+
+The `id` for the typeahead input field, to use with a `<label for=id>`. Required if you're instantiating more than one typeahead in one page.
+
+#### `minLength: Number` (default: `0`)
+
+The minimum number of characters that should be entered before the typeahead will attempt to suggest options. When the query length is under this, the aria status region will also provide helpful text to the user informing them they should type in more.
+
+#### `name: String` (default: `'input-typeahead'`)
+
+The `name` for the typeahead input field, to use with a parent `<form>`.
+
+## Progressive enhancement
+
+If your typeahead is meant to select from a small list of options (a few hundreds), we strongly suggest that you render a `<select>` menu on the server, and use progressive enhancement.
+
+If you have the following HTML:
+
+```html
+<select id="location-picker">
+  <option value="fr">France</option>
+  <option value="de">Germany</option>
+  <option value="gb" selected>United Kingdom</option>
+</select>
+```
+
+You can use the `AccessibleTypeahead.enhanceSelectElement` function to enhance it into a typeahead:
+
+```js
+AccessibleTypeahead.enhanceSelectElement({
+  selectElement: document.querySelector('#location-picker')
+})
+```
+
+This will:
+
+- Place a typeahead input field adjacent to the specified `<select>`
+- Set the typeahead `defaultValue` to the `option[selected]` if any
+- Default the typeahead `id` to the `<select>`'s `id`
+- Default the typeahead `name` attribute to `''` to prevent it being included in form submissions
+- Default the typeahead `source` to a basic one that uses any existing `<option>`s from the `<select>`
+- Hide the `<select>` using inline `display: none`
+- Set the `<select>`'s id to `${id}-select` to decouple from any `<label>`
+- Upon selecting a value in the typeahead, update the original `<select>`
+
+This function takes the same options as `AccessibleTypeahead`, with two differences:
+
+- `selectElement` is used instead of `element`
+- `defaultValue` is not used, it's inferred from the `option[selected]` if any
+
+> **Note**: The `AccessibleTypeahead.enhanceSelectElement` function is fairly light and wraps the public API for `AccessibleTypeahead`. If your use case doesn't fit the above defaults, try [reading the source](src/wrapper.jsx) and seeing if you can write your own.
 
 ## Why another typeahead?
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -46,6 +46,16 @@
       <h2>defaultValue = 'Germany'</h2>
       <label for="typeahead-defaultValue">Select your country</label>
       <div id="tt-defaultValue" class="typeahead-wrapper"></div>
+
+      <h2>Progressive enhancement</h2>
+      <label for="typeahead-progressiveEnhancement">Select your country</label>
+      <div class="typeahead-wrapper">
+        <select id="typeahead-progressiveEnhancement">
+          <option value="fr">France</option>
+          <option value="de">Germany</option>
+          <option value="gb" selected>United Kingdom</option>
+        </select>
+      </div>
     </main>
 
     <script type="text/javascript" src="../dist/accessible-typeahead.min.js"></script>
@@ -116,6 +126,13 @@
         element: element,
         id: id,
         source: suggest
+      })
+    </script>
+
+    <script type="text/javascript">
+      element = document.querySelector('#typeahead-progressiveEnhancement')
+      AccessibleTypeahead.enhanceSelectElement({
+        selectElement: element
       })
     </script>
   </body>

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -20,7 +20,8 @@ export default class Typeahead extends Component {
     displayMenu: 'inline',
     id: 'typeahead',
     minLength: 0,
-    name: 'input-typeahead'
+    name: 'input-typeahead',
+    onSelect: () => {}
   }
 
   elementRefs = {}
@@ -107,12 +108,14 @@ export default class Typeahead extends Component {
 
   handleComponentBlur (newState) {
     const { query } = this.state
+    const newQuery = newState.query || query
     this.setState({
       focused: null,
       menuOpen: newState.menuOpen || false,
-      query: newState.query || query,
+      query: newQuery,
       selected: null
     })
+    this.props.onSelect(newQuery)
   }
 
   handleOptionFocusOut (evt, idx) {
@@ -205,12 +208,14 @@ export default class Typeahead extends Component {
   }
 
   handleOptionClick (evt, idx) {
+    const newQuery = this.state.options[idx]
     this.setState({
       focused: -1,
       menuOpen: false,
-      query: this.state.options[idx],
+      query: newQuery,
       selected: -1
     })
+    this.props.onSelect(newQuery)
   }
 
   handleOptionMouseDown (evt) {

--- a/src/wrapper.jsx
+++ b/src/wrapper.jsx
@@ -40,7 +40,10 @@ AccessibleTypeahead.enhanceSelectElement = ({
   autoselect,
   cssNamespace,
   displayMenu,
+  id,
   minLength,
+  name,
+  onSelect,
   selectElement,
   source
 }) => {
@@ -49,20 +52,21 @@ AccessibleTypeahead.enhanceSelectElement = ({
     source = createSimpleEngine(availableOptions)
   }
 
+  if (!onSelect) {
+    onSelect = (query) => {
+      const requestedOption = Array.prototype.filter.call(selectElement.options, o => o.innerHTML === query)[0]
+      if (requestedOption) { requestedOption.selected = true }
+    }
+  }
+
+  name = name || ''
+  id = id || selectElement.id
+
   const selectedOption = Array.prototype.filter.call(selectElement.options, o => o.selected)[0]
   const defaultValue = selectedOption ? selectedOption.innerHTML : ''
 
-  const name = ''
-
-  const id = selectElement.id
-
   const element = document.createElement('span')
   selectElement.insertAdjacentElement('afterend', element)
-
-  const onSelect = (query) => {
-    const requestedOption = Array.prototype.filter.call(selectElement.options, o => o.innerHTML === query)[0]
-    if (requestedOption) { requestedOption.selected = true }
-  }
 
   render(
     <Typeahead

--- a/src/wrapper.jsx
+++ b/src/wrapper.jsx
@@ -1,30 +1,88 @@
 import { h, render } from 'preact' /** @jsx h */
 import Typeahead from './typeahead'
 
-if (window) {
-  window.AccessibleTypeahead = function ({
-    autoselect,
-    cssNamespace,
-    defaultValue,
-    displayMenu,
-    element,
-    id,
-    minLength,
-    name,
-    source
-  }) {
-    render(
-      <Typeahead
-        autoselect={autoselect}
-        cssNamespace={cssNamespace}
-        defaultValue={defaultValue}
-        displayMenu={displayMenu}
-        id={id}
-        minLength={minLength}
-        name={name}
-        source={source}
-      />,
-      element
-    )
+function AccessibleTypeahead ({
+  autoselect,
+  cssNamespace,
+  defaultValue,
+  displayMenu,
+  element,
+  id,
+  minLength,
+  name,
+  onSelect,
+  source
+}) {
+  render(
+    <Typeahead
+      autoselect={autoselect}
+      cssNamespace={cssNamespace}
+      defaultValue={defaultValue}
+      displayMenu={displayMenu}
+      id={id}
+      minLength={minLength}
+      name={name}
+      onSelect={onSelect}
+      source={source}
+    />,
+    element
+  )
+}
+
+const createSimpleEngine = results => (query, syncResults) => {
+  const filteredResults = query
+    ? results.filter(r => r.toLowerCase().indexOf(query.toLowerCase()) !== -1)
+    : []
+  syncResults(filteredResults)
+}
+
+AccessibleTypeahead.enhanceSelectElement = ({
+  autoselect,
+  cssNamespace,
+  displayMenu,
+  minLength,
+  selectElement,
+  source
+}) => {
+  if (!source) {
+    const availableOptions = Array.prototype.map.call(selectElement.options, o => o.innerHTML)
+    source = createSimpleEngine(availableOptions)
   }
+
+  const selectedOption = Array.prototype.filter.call(selectElement.options, o => o.selected)[0]
+  const defaultValue = selectedOption ? selectedOption.innerHTML : ''
+
+  const name = ''
+
+  const id = selectElement.id
+
+  const element = document.createElement('span')
+  selectElement.insertAdjacentElement('afterend', element)
+
+  const onSelect = (query) => {
+    const requestedOption = Array.prototype.filter.call(selectElement.options, o => o.innerHTML === query)[0]
+    if (requestedOption) { requestedOption.selected = true }
+  }
+
+  render(
+    <Typeahead
+      autoselect={autoselect}
+      cssNamespace={cssNamespace}
+      defaultValue={defaultValue}
+      displayMenu={displayMenu}
+      id={id}
+      minLength={minLength}
+      name={name}
+      onSelect={onSelect}
+      source={source}
+    />,
+    element
+  )
+
+  selectElement.style.display = 'none'
+  selectElement.id = selectElement.id + '-select'
+}
+
+if (window) {
+  window.AccessibleTypeahead = AccessibleTypeahead
 }

--- a/src/wrapper.jsx
+++ b/src/wrapper.jsx
@@ -36,55 +36,33 @@ const createSimpleEngine = results => (query, syncResults) => {
   syncResults(filteredResults)
 }
 
-AccessibleTypeahead.enhanceSelectElement = ({
-  autoselect,
-  cssNamespace,
-  displayMenu,
-  id,
-  minLength,
-  name,
-  onSelect,
-  selectElement,
-  source
-}) => {
-  if (!source) {
-    const availableOptions = Array.prototype.map.call(selectElement.options, o => o.innerHTML)
-    source = createSimpleEngine(availableOptions)
+AccessibleTypeahead.enhanceSelectElement = (opts) => {
+  // Set defaults.
+  if (!opts.source) {
+    const availableOptions = Array.prototype.map.call(opts.selectElement.options, o => o.innerHTML)
+    opts.source = createSimpleEngine(availableOptions)
   }
+  opts.onSelect = opts.onSelect || (query => {
+    const requestedOption = Array.prototype.filter.call(opts.selectElement.options, o => o.innerHTML === query)[0]
+    if (requestedOption) { requestedOption.selected = true }
+  })
+  opts.name = opts.name || ''
+  opts.id = opts.id || opts.selectElement.id
 
-  if (!onSelect) {
-    onSelect = (query) => {
-      const requestedOption = Array.prototype.filter.call(selectElement.options, o => o.innerHTML === query)[0]
-      if (requestedOption) { requestedOption.selected = true }
-    }
-  }
-
-  name = name || ''
-  id = id || selectElement.id
-
-  const selectedOption = Array.prototype.filter.call(selectElement.options, o => o.selected)[0]
+  const selectedOption = Array.prototype.filter.call(opts.selectElement.options, o => o.selected)[0]
   const defaultValue = selectedOption ? selectedOption.innerHTML : ''
 
   const element = document.createElement('span')
-  selectElement.insertAdjacentElement('afterend', element)
+  opts.selectElement.insertAdjacentElement('afterend', element)
 
-  render(
-    <Typeahead
-      autoselect={autoselect}
-      cssNamespace={cssNamespace}
-      defaultValue={defaultValue}
-      displayMenu={displayMenu}
-      id={id}
-      minLength={minLength}
-      name={name}
-      onSelect={onSelect}
-      source={source}
-    />,
-    element
-  )
+  AccessibleTypeahead({
+    ...opts,
+    defaultValue: defaultValue,
+    element: element
+  })
 
-  selectElement.style.display = 'none'
-  selectElement.id = selectElement.id + '-select'
+  opts.selectElement.style.display = 'none'
+  opts.selectElement.id = opts.selectElement.id + '-select'
 }
 
 if (window) {

--- a/test/browser/index.jsx
+++ b/test/browser/index.jsx
@@ -60,7 +60,7 @@ describe('Typeahead', () => {
   })
 
   describe('behaviour', () => {
-    let typeahead, autoselectTypeahead
+    let typeahead, autoselectTypeahead, onSelectTypeahead, onSelectTriggered, autoselectOnSelectTypeahead
 
     beforeEach(() => {
       typeahead = new Typeahead({
@@ -73,6 +73,22 @@ describe('Typeahead', () => {
         ...Typeahead.defaultProps,
         autoselect: true,
         id: 'test2',
+        source: suggest
+      })
+
+      onSelectTriggered = false
+      onSelectTypeahead = new Typeahead({
+        ...Typeahead.defaultProps,
+        id: 'test3',
+        onSelect: () => { onSelectTriggered = true },
+        source: suggest
+      })
+
+      autoselectOnSelectTypeahead = new Typeahead({
+        ...Typeahead.defaultProps,
+        autoselect: true,
+        id: 'test4',
+        onSelect: () => { onSelectTriggered = true },
         source: suggest
       })
     })
@@ -179,13 +195,14 @@ describe('Typeahead', () => {
         expect(typeahead.state.query).to.equal('fr')
       })
 
-      describe('autoselect', () => {
-        it('unfocuses component, updates query', () => {
-          autoselectTypeahead.setState({ menuOpen: true, options: ['France'], query: 'fr', focused: -1, selected: 0 })
-          autoselectTypeahead.handleInputBlur({ target: 'mock', relatedTarget: 'relatedMock' }, 0)
-          expect(autoselectTypeahead.state.focused).to.equal(null)
-          expect(autoselectTypeahead.state.menuOpen).to.equal(false)
-          expect(autoselectTypeahead.state.query).to.equal('France')
+      describe('with autoselect and onSelect', () => {
+        it('unfocuses component, updates query, triggers onSelect', () => {
+          autoselectOnSelectTypeahead.setState({ menuOpen: true, options: ['France'], query: 'fr', focused: -1, selected: 0 })
+          autoselectOnSelectTypeahead.handleInputBlur({ target: 'mock', relatedTarget: 'relatedMock' }, 0)
+          expect(autoselectOnSelectTypeahead.state.focused).to.equal(null)
+          expect(autoselectOnSelectTypeahead.state.menuOpen).to.equal(false)
+          expect(autoselectOnSelectTypeahead.state.query).to.equal('France')
+          expect(onSelectTriggered).to.equal(true)
         })
       })
     })
@@ -315,15 +332,16 @@ describe('Typeahead', () => {
 
     describe('enter key', () => {
       describe('on an option', () => {
-        it('prevents default, closes the menu, sets the query, focuses the input', () => {
+        it('prevents default, closes the menu, sets the query, focuses the input, triggers onSelect', () => {
           let preventedDefault = false
-          typeahead.setState({ menuOpen: true, options: ['France'], focused: 0, selected: 0 })
-          typeahead.handleKeyDown({ preventDefault: () => { preventedDefault = true }, keyCode: 13 })
-          expect(typeahead.state.menuOpen).to.equal(false)
-          expect(typeahead.state.query).to.equal('France')
-          expect(typeahead.state.focused).to.equal(-1)
-          expect(typeahead.state.selected).to.equal(-1)
+          onSelectTypeahead.setState({ menuOpen: true, options: ['France'], focused: 0, selected: 0 })
+          onSelectTypeahead.handleKeyDown({ preventDefault: () => { preventedDefault = true }, keyCode: 13 })
+          expect(onSelectTypeahead.state.menuOpen).to.equal(false)
+          expect(onSelectTypeahead.state.query).to.equal('France')
+          expect(onSelectTypeahead.state.focused).to.equal(-1)
+          expect(onSelectTypeahead.state.selected).to.equal(-1)
           expect(preventedDefault).to.equal(true)
+          expect(onSelectTriggered).to.equal(true)
         })
       })
 


### PR DESCRIPTION
This PR adds a `AccessibleTypeahead.enhanceSelectElement` helper function which will:

- Place a typeahead input field adjacent to the specified `<select>`
- Set the typeahead `defaultValue` to the `option[selected]` if any
- Default the typeahead `id` to the `<select>`'s `id`
- Default the typeahead `name` attribute to `''` to prevent it being included in form submissions
- Default the typeahead `source` to a basic one that uses any existing `<option>`s from the `<select>`
- Hide the `<select>` using inline `display: none`
- Set the `<select>`'s id to `${id}-select` to decouple from any `<label>`
- Upon selecting a value in the typeahead, update the original `<select>`

Also includes some README reorg/cleanup.

Closes #25.