### PR TITLE
`onSelect` fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 _(add items here for easier creation of next log entry)_
 
+- Pass actual selected object into `onSelect`.
+
 ## 0.3.3 - 2017-04-04
 
 - Add `templates.inputValue` and `templates.suggestion` properties. These allow users to override how the suggestions are displayed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 _(add items here for easier creation of next log entry)_
 
 - Pass actual selected object into `onSelect`.
+- Add `selectOnBlur` property to allow users to disable this behaviour.
 
 ## 0.3.3 - 2017-04-04
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Arguments: `selected: Object`
 
 This function will be called when the user selects an option, with the option they've selected.
 
+#### `selectOnBlur` (default: `true`)
+
+Type: `PropTypes.bool`
+
+Set this value to `false` to stop the typeahead from automatically confirming a value when it has been selected using autoselect or the keyboard and the user "blurs" (clicks outside of the component).
+
 #### `templates` (default: `undefined`)
 
 Type:

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The `name` for the typeahead input field, to use with a parent `<form>`.
 
 Type: `PropTypes.func`
 
-Arguments: `query: string`
+Arguments: `selected: Object`
 
 This function will be called when the user selects an option, with the option they've selected.
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -57,6 +57,15 @@
       <label for="typeahead-defaultValue">Select your country</label>
       <div id="tt-defaultValue" class="typeahead-wrapper"></div>
 
+      <h3><code>selectOnBlur: false</code></h3>
+      <p>
+        This option will toggle automatically confirming a selection on blur. In the other
+        examples, if you select an option using the arrow keys and then click out, it will
+        confirm the selection.
+      </p>
+      <label for="typeahead-selectOnBlur">Select your country</label>
+      <div id="tt-selectOnBlur" class="typeahead-wrapper"></div>
+
       <h2>Advanced features</h2>
 
       <h3>Progressive enhancement</h3>
@@ -200,6 +209,17 @@
           inputValue: inputValueTemplate,
           suggestion: suggestionTemplate
         }
+      })
+    </script>
+
+    <script type="text/javascript">
+      element = document.querySelector('#tt-selectOnBlur')
+      id = 'typeahead-selectOnBlur'
+      AccessibleTypeahead({
+        element: element,
+        id: id,
+        selectOnBlur: false,
+        source: suggest
       })
     </script>
   </body>

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -21,7 +21,8 @@ export default class Typeahead extends Component {
     id: 'typeahead',
     minLength: 0,
     name: 'input-typeahead',
-    onSelect: () => {}
+    onSelect: () => {},
+    selectOnBlur: true
   }
 
   elementRefs = {}
@@ -120,8 +121,13 @@ export default class Typeahead extends Component {
 
   handleComponentBlur (newState) {
     const { options, query, selected } = this.state
-    const newQuery = newState.query || query
-    this.props.onSelect(options[selected])
+    let newQuery
+    if (this.props.selectOnBlur) {
+      newQuery = newState.query || query
+      this.props.onSelect(options[selected])
+    } else {
+      newQuery = query
+    }
     this.setState({
       focused: null,
       menuOpen: newState.menuOpen || false,

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -119,15 +119,15 @@ export default class Typeahead extends Component {
   }
 
   handleComponentBlur (newState) {
-    const { query } = this.state
+    const { options, query, selected } = this.state
     const newQuery = newState.query || query
+    this.props.onSelect(options[selected])
     this.setState({
       focused: null,
       menuOpen: newState.menuOpen || false,
       query: newQuery,
       selected: null
     })
-    this.props.onSelect(newQuery)
   }
 
   handleOptionFocusOut (evt, idx) {
@@ -220,14 +220,15 @@ export default class Typeahead extends Component {
   }
 
   handleOptionClick (evt, idx) {
-    const newQuery = this.templateInputValue(this.state.options[idx])
+    const selectedOption = this.state.options[idx]
+    const newQuery = this.templateInputValue(selectedOption)
+    this.props.onSelect(selectedOption)
     this.setState({
       focused: -1,
       menuOpen: false,
       query: newQuery,
       selected: -1
     })
-    this.props.onSelect(newQuery)
   }
 
   handleOptionMouseDown (evt) {

--- a/src/wrapper.jsx
+++ b/src/wrapper.jsx
@@ -11,6 +11,7 @@ function AccessibleTypeahead ({
   minLength,
   name,
   onSelect,
+  selectOnBlur,
   source,
   templates
 }) {
@@ -24,6 +25,7 @@ function AccessibleTypeahead ({
       minLength={minLength}
       name={name}
       onSelect={onSelect}
+      selectOnBlur={selectOnBlur}
       source={source}
       templates={templates}
     />,

--- a/test/browser/index.jsx
+++ b/test/browser/index.jsx
@@ -60,7 +60,8 @@ describe('Typeahead', () => {
   })
 
   describe('behaviour', () => {
-    let typeahead, autoselectTypeahead, onSelectTypeahead, onSelectTriggered, autoselectOnSelectTypeahead
+    let typeahead, autoselectTypeahead, onSelectTypeahead, onSelectTriggered,
+      autoselectOnSelectTypeahead, selectOnBlurTypeahead
 
     beforeEach(() => {
       typeahead = new Typeahead({
@@ -89,6 +90,14 @@ describe('Typeahead', () => {
         autoselect: true,
         id: 'test4',
         onSelect: () => { onSelectTriggered = true },
+        source: suggest
+      })
+
+      selectOnBlurTypeahead = new Typeahead({
+        ...Typeahead.defaultProps,
+        id: 'test5',
+        onSelect: () => { onSelectTriggered = true },
+        selectOnBlur: false,
         source: suggest
       })
     })
@@ -205,6 +214,17 @@ describe('Typeahead', () => {
           expect(onSelectTriggered).to.equal(true)
         })
       })
+
+      describe('with selectOnBlur false', () => {
+        it('unfocuses component, does not touch query, does not trigger onSelect', () => {
+          selectOnBlurTypeahead.setState({ menuOpen: true, options: ['France'], query: 'fr', focused: -1, selected: 0 })
+          selectOnBlurTypeahead.handleInputBlur({ target: 'mock', relatedTarget: 'relatedMock' }, 0)
+          expect(selectOnBlurTypeahead.state.focused).to.equal(null)
+          expect(selectOnBlurTypeahead.state.menuOpen).to.equal(false)
+          expect(selectOnBlurTypeahead.state.query).to.equal('fr')
+          expect(onSelectTriggered).to.equal(false)
+        })
+      })
     })
 
     describe('focusing option', () => {
@@ -227,12 +247,23 @@ describe('Typeahead', () => {
       })
 
       describe('with option selected', () => {
-        it('unfocuses component, updates query', () => {
-          typeahead.setState({ menuOpen: true, options: ['France'], query: 'fr', focused: 0, selected: 0 })
-          typeahead.handleOptionFocusOut({ target: 'mock', relatedTarget: 'relatedMock' }, 0)
-          expect(typeahead.state.focused).to.equal(null)
-          expect(typeahead.state.menuOpen).to.equal(false)
-          expect(typeahead.state.query).to.equal('France')
+        describe('with selectOnBlur true', () => {
+          it('unfocuses component, updates query', () => {
+            typeahead.setState({ menuOpen: true, options: ['France'], query: 'fr', focused: 0, selected: 0 })
+            typeahead.handleOptionFocusOut({ target: 'mock', relatedTarget: 'relatedMock' }, 0)
+            expect(typeahead.state.focused).to.equal(null)
+            expect(typeahead.state.menuOpen).to.equal(false)
+            expect(typeahead.state.query).to.equal('France')
+          })
+        })
+        describe('with selectOnBlur false', () => {
+          it('unfocuses component, does not update query', () => {
+            selectOnBlurTypeahead.setState({ menuOpen: true, options: ['France'], query: 'fr', focused: 0, selected: 0 })
+            selectOnBlurTypeahead.handleOptionFocusOut({ target: 'mock', relatedTarget: 'relatedMock' }, 0)
+            expect(selectOnBlurTypeahead.state.focused).to.equal(null)
+            expect(selectOnBlurTypeahead.state.menuOpen).to.equal(false)
+            expect(selectOnBlurTypeahead.state.query).to.equal('fr')
+          })
         })
       })
     })


### PR DESCRIPTION
- Pass actual selected object into `onSelect`.
- Add `selectOnBlur` property to allow users to disable this behaviour.