### PR TITLE
Don't focus suggestions when hovering them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 _(add items here for easier creation of next log entry)_
 
+- [Breaking] Don't focus suggestions when hovering them, add `:hover` CSS class.
 - Add `showNoOptionsFound` property to allow users to disable this behaviour.
 - Pass through unrecognised key events to input, allowing users to continue typing when they are focusing an option.
 

--- a/examples/styled.css
+++ b/examples/styled.css
@@ -82,7 +82,8 @@
   background-color: #FAFAFA;
 }
 
-.typeahead__option--focused {
+.typeahead__option--focused,
+.typeahead__option:hover {
   background-color: #005EA5;
   border-color: #005EA5;
   color: white;

--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -45,6 +45,7 @@ export default class Typeahead extends Component {
 
     this.state = {
       focused: null,
+      hovered: null,
       menuOpen: false,
       options: props.defaultValue ? [props.defaultValue] : [],
       query: props.defaultValue,
@@ -62,7 +63,7 @@ export default class Typeahead extends Component {
     this.handleOptionFocusOut = this.handleOptionFocusOut.bind(this)
     this.handleOptionFocus = this.handleOptionFocus.bind(this)
     this.handleOptionMouseDown = this.handleOptionMouseDown.bind(this)
-    this.handleOptionMouseMove = this.handleOptionMouseMove.bind(this)
+    this.handleOptionMouseEnter = this.handleOptionMouseEnter.bind(this)
     this.handleOptionMouseOut = this.handleOptionMouseOut.bind(this)
 
     this.handleInputBlur = this.handleInputBlur.bind(this)
@@ -216,27 +217,21 @@ export default class Typeahead extends Component {
   handleOptionFocus (idx) {
     this.setState({
       focused: idx,
+      hovered: null,
       selected: idx
     })
   }
 
-  handleOptionMouseMove (idx) {
+  handleOptionMouseEnter (evt, idx) {
     this.setState({
-      focused: idx
+      hovered: idx
     })
   }
 
   handleOptionMouseOut (evt, idx) {
-    const previousOption = this.elementRefs[idx - 1]
-    const nextOption = this.elementRefs[idx + 1]
-    const toElement = evt.toElement
-    const movingToAnotherOption = toElement === previousOption || toElement === nextOption
-    const focusBackOnSelectedOption = !movingToAnotherOption
-    if (focusBackOnSelectedOption) {
-      this.setState({
-        focused: this.state.selected
-      })
-    }
+    this.setState({
+      hovered: null
+    })
   }
 
   handleOptionClick (evt, idx) {
@@ -325,7 +320,7 @@ export default class Typeahead extends Component {
 
   render () {
     const { cssNamespace, displayMenu, id, minLength, name } = this.props
-    const { focused, menuOpen, options, query, selected } = this.state
+    const { focused, hovered, menuOpen, options, query, selected } = this.state
     const autoselect = this.hasAutoselect()
 
     const inputFocused = focused === -1
@@ -403,7 +398,7 @@ export default class Typeahead extends Component {
     const Option = ({ dangerouslySetInnerHTML, idx }) => {
       const cn = `${cssNamespace}__option`
       const showFocused = focused === -1 ? selected === idx : focused === idx
-      const cnModFocused = showFocused ? ` ${cn}--focused` : ''
+      const cnModFocused = showFocused && hovered === null ? ` ${cn}--focused` : ''
       const cnModOdd = (idx % 2) ? ` ${cn}--odd` : ''
       const cns = `${cn}${cnModFocused}${cnModOdd}`
       return <li
@@ -414,7 +409,7 @@ export default class Typeahead extends Component {
         onClick={(evt) => this.handleOptionClick(evt, idx)}
         onFocusOut={(evt) => this.handleOptionFocusOut(evt, idx)}
         onMouseDown={this.handleOptionMouseDown}
-        onMouseMove={() => this.handleOptionMouseMove(idx)}
+        onMouseEnter={(evt) => this.handleOptionMouseEnter(evt, idx)}
         onMouseOut={(evt) => this.handleOptionMouseOut(evt, idx)}
         role='option'
         tabindex='-1'

--- a/test/browser/index.jsx
+++ b/test/browser/index.jsx
@@ -269,18 +269,20 @@ describe('Typeahead', () => {
     })
 
     describe('hovering option', () => {
-      it('sets the option as focused, does not change selected', () => {
-        typeahead.setState({ options: ['France'], focused: -1, selected: -1 })
-        typeahead.handleOptionMouseMove(0)
-        expect(typeahead.state.focused).to.equal(0)
+      it('sets the option as hovered, does not change focused, does not change selected', () => {
+        typeahead.setState({ options: ['France'], hovered: null, focused: -1, selected: -1 })
+        typeahead.handleOptionMouseEnter({}, 0)
+        expect(typeahead.state.hovered).to.equal(0)
+        expect(typeahead.state.focused).to.equal(-1)
         expect(typeahead.state.selected).to.equal(-1)
       })
     })
 
     describe('hovering out option', () => {
-      it('sets focus back on selected', () => {
-        typeahead.setState({ options: ['France'], focused: 0, selected: -1 })
+      it('sets focus back on selected, sets hovered to null', () => {
+        typeahead.setState({ options: ['France'], hovered: 0, focused: -1, selected: -1 })
         typeahead.handleOptionMouseOut({ toElement: 'mock' }, 0)
+        expect(typeahead.state.hovered).to.equal(null)
         expect(typeahead.state.focused).to.equal(-1)
         expect(typeahead.state.selected).to.equal(-1)
       })


### PR DESCRIPTION
The way hovering previously worked is it would `.focus` the underlying element, which would apply the focus styles.

The reason it was done this way was because the component was built with keyboard in mind before mouse; for keyboard use to work well with assistive technologies, focusing is necessary for the current implementation. When I added mouse support, I made the mouse perform the same action as the keyboard, which is focusing.

This had an added benefit: when using a screenreader like VoiceOver, focusing on suggestions while the user mouses over them would make VoiceOver speak them out, which could be seen as a win for users with enough sight to use the mouse, but that need to rely on a screen reader to actually read words.

However, the side effect to this is when using the typeahead with lots of options. Focusing while you're scrolling is jittery, because focusing an element inside a scrollable parent will always attempt to scroll it into view.

This is a breaking change because it changes existing behaviour with assistive technologies and also the public CSS API.

This is done using a JavaScript-based `--hovered` class instead of a CSS `:hover` pseudo-class. This is because when the user has focused an element using the keyboard, and uses the mouse to hover over something else, we want the mouse hover to take priority and not highlight the focused element. This is not possible using CSS because there [it doesn't have a no sibling selector](http://stackoverflow.com/questions/7866784/css-no-sibling-selector).