### PR TITLE
Write tests for wrapper

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -432,7 +432,6 @@
     <script type="text/javascript">
       element = document.querySelector('#typeahead-progressiveEnhancement')
       AccessibleTypeahead.enhanceSelectElement({
-        defaultValue: element.options[element.options.selectedIndex].innerHTML,
         selectElement: element
       })
     </script>

--- a/src/wrapper.jsx
+++ b/src/wrapper.jsx
@@ -54,8 +54,8 @@ AccessibleTypeahead.enhanceSelectElement = (opts) => {
     const requestedOption = Array.prototype.filter.call(opts.selectElement.options, o => o.innerHTML === query)[0]
     if (requestedOption) { requestedOption.selected = true }
   })
-  opts.name = opts.name || ''
-  opts.id = opts.id || opts.selectElement.id
+  opts.name = opts.name || opts.selectElement.name || ''
+  opts.id = opts.id || opts.selectElement.id || ''
 
   const element = document.createElement('span')
   opts.selectElement.insertAdjacentElement('afterend', element)

--- a/src/wrapper.jsx
+++ b/src/wrapper.jsx
@@ -54,6 +54,9 @@ AccessibleTypeahead.enhanceSelectElement = (opts) => {
     const requestedOption = Array.prototype.filter.call(opts.selectElement.options, o => o.innerHTML === query)[0]
     if (requestedOption) { requestedOption.selected = true }
   })
+  if (!opts.defaultValue) {
+    opts.defaultValue = opts.selectElement.options[opts.selectElement.options.selectedIndex].innerHTML
+  }
   opts.name = opts.name || opts.selectElement.name || ''
   opts.id = opts.id || opts.selectElement.id || ''
 

--- a/src/wrapper.jsx
+++ b/src/wrapper.jsx
@@ -56,6 +56,8 @@ AccessibleTypeahead.enhanceSelectElement = (opts) => {
   })
   if (!opts.defaultValue) {
     opts.defaultValue = opts.selectElement.options[opts.selectElement.options.selectedIndex].innerHTML
+  } else {
+    opts.selectElement.value = opts.defaultValue
   }
   opts.name = opts.name || opts.selectElement.name || ''
   opts.id = opts.id || opts.selectElement.id || ''

--- a/test/browser/wrapper.jsx
+++ b/test/browser/wrapper.jsx
@@ -1,9 +1,45 @@
 /* global describe, expect, it */
 import Wrapper from '../../src/wrapper'
 
+const injectSelectToEnhanceIntoDOM = (id) => {
+  const options = {
+    fr: 'France',
+    de: 'Germany',
+    gb: 'United Kingdom'
+  }
+
+  var $select = document.createElement('select')
+  $select.id = id
+  $select.name = id
+
+  for (var optionKey in options) {
+    var option = document.createElement('option')
+    option.value = optionKey
+    option.text = options[optionKey]
+    $select.appendChild(option)
+  }
+
+  document.body.appendChild($select)
+}
+
 describe('Wrapper', () => {
   it('exposes global on window', () => {
     expect(typeof Wrapper).to.equal('object')
     expect(typeof window.AccessibleTypeahead).to.equal('function')
+  })
+  it('can enhance a select element', () => {
+    const id = 'location-picker'
+    injectSelectToEnhanceIntoDOM(id)
+
+    window.AccessibleTypeahead.enhanceSelectElement({
+      selectElement: document.querySelector('#' + id)
+    })
+
+    const typeaheadInstances = document.querySelectorAll('.typeahead__wrapper')
+    expect(typeaheadInstances.length).to.equal(1)
+
+    const typeaheadInstance = typeaheadInstances[0]
+    expect(typeaheadInstance.innerHTML).to.contain(`id="${id}"`)
+    expect(typeaheadInstance.innerHTML).to.contain(`name="${id}"`)
   })
 })

--- a/test/browser/wrapper.jsx
+++ b/test/browser/wrapper.jsx
@@ -1,0 +1,9 @@
+/* global describe, expect, it */
+import Wrapper from '../../src/wrapper'
+
+describe('Wrapper', () => {
+  it('exposes global on window', () => {
+    expect(typeof Wrapper).to.equal('object')
+    expect(typeof window.AccessibleTypeahead).to.equal('function')
+  })
+})

--- a/test/browser/wrapper.jsx
+++ b/test/browser/wrapper.jsx
@@ -1,21 +1,21 @@
 /* global describe, expect, it */
 import Wrapper from '../../src/wrapper'
 
-const injectSelectToEnhanceIntoDOM = (id) => {
-  const options = {
-    fr: 'France',
-    de: 'Germany',
-    gb: 'United Kingdom'
+const injectSelectToEnhanceIntoDOM = (id, name, options, selectedOption) => {
+  var maybeCurrentInstance = document.getElementById(id)
+  if (maybeCurrentInstance) {
+    document.body.removeChild(maybeCurrentInstance)
   }
 
   var $select = document.createElement('select')
   $select.id = id
-  $select.name = id
+  $select.name = name
 
   for (var optionKey in options) {
     var option = document.createElement('option')
     option.value = optionKey
     option.text = options[optionKey]
+    option.selected = (selectedOption === optionKey)
     $select.appendChild(option)
   }
 
@@ -28,8 +28,15 @@ describe('Wrapper', () => {
     expect(typeof window.AccessibleTypeahead).to.equal('function')
   })
   it('can enhance a select element', () => {
-    const id = 'location-picker'
-    injectSelectToEnhanceIntoDOM(id)
+    const id = 'location-picker-id'
+    const name = 'location-picker-name'
+    const options = {
+      fr: 'France',
+      de: 'Germany',
+      gb: 'United Kingdom'
+    }
+    const selectedOption = 'gb'
+    injectSelectToEnhanceIntoDOM(id, name, options, selectedOption)
 
     window.AccessibleTypeahead.enhanceSelectElement({
       selectElement: document.querySelector('#' + id)
@@ -40,6 +47,9 @@ describe('Wrapper', () => {
 
     const typeaheadInstance = typeaheadInstances[0]
     expect(typeaheadInstance.innerHTML).to.contain(`id="${id}"`)
-    expect(typeaheadInstance.innerHTML).to.contain(`name="${id}"`)
+    expect(typeaheadInstance.innerHTML).to.contain(`name="${name}"`)
+
+    const typeaheadOption = typeaheadInstance.querySelector('.typeahead__option')
+    expect(typeaheadOption.textContent).to.equal(options[selectedOption])
   })
 })

--- a/test/browser/wrapper.jsx
+++ b/test/browser/wrapper.jsx
@@ -1,15 +1,14 @@
-/* global describe, expect, it */
+/* global before, beforeEach, after, describe, expect, it */
 import Wrapper from '../../src/wrapper'
 
-const injectSelectToEnhanceIntoDOM = (id, name, options, selectedOption) => {
-  var maybeCurrentInstance = document.getElementById(id)
-  if (maybeCurrentInstance) {
-    document.body.removeChild(maybeCurrentInstance)
-  }
-
+const injectSelectToEnhanceIntoDOM = (element, id, name, options, selectedOption) => {
   var $select = document.createElement('select')
-  $select.id = id
-  $select.name = name
+  if (id) {
+    $select.id = id
+  }
+  if (name) {
+    $select.name = name
+  }
 
   for (var optionKey in options) {
     var option = document.createElement('option')
@@ -19,14 +18,30 @@ const injectSelectToEnhanceIntoDOM = (id, name, options, selectedOption) => {
     $select.appendChild(option)
   }
 
-  document.body.appendChild($select)
+  element.appendChild($select)
 }
 
 describe('Wrapper', () => {
+  let scratch
+  before(() => {
+    scratch = document.createElement('div');
+    (document.body || document.documentElement).appendChild(scratch)
+  })
+
+  beforeEach(() => {
+    scratch.innerHTML = ''
+  })
+
+  after(() => {
+    scratch.parentNode.removeChild(scratch)
+    scratch = null
+  })
+
   it('exposes global on window', () => {
     expect(typeof Wrapper).to.equal('object')
     expect(typeof window.AccessibleTypeahead).to.equal('function')
   })
+
   it('can enhance a select element', () => {
     const id = 'location-picker-id'
     const name = 'location-picker-name'
@@ -36,7 +51,7 @@ describe('Wrapper', () => {
       gb: 'United Kingdom'
     }
     const selectedOption = 'gb'
-    injectSelectToEnhanceIntoDOM(id, name, options, selectedOption)
+    injectSelectToEnhanceIntoDOM(scratch, id, name, options, selectedOption)
 
     window.AccessibleTypeahead.enhanceSelectElement({
       selectElement: document.querySelector('#' + id)
@@ -51,5 +66,116 @@ describe('Wrapper', () => {
 
     const typeaheadOption = typeaheadInstance.querySelector('.typeahead__option')
     expect(typeaheadOption.textContent).to.equal(options[selectedOption])
+  })
+
+  it('can enhance a select element no name', () => {
+    const id = false
+    const name = false
+    const options = {
+      fr: 'France',
+      de: 'Germany',
+      gb: 'United Kingdom'
+    }
+    injectSelectToEnhanceIntoDOM(scratch, id, name, options)
+
+    window.AccessibleTypeahead.enhanceSelectElement({
+      selectElement: document.querySelector('select')
+    })
+
+    const typeaheadInstances = document.querySelectorAll('.typeahead__wrapper')
+    expect(typeaheadInstances.length).to.equal(1)
+
+    const typeaheadInstance = typeaheadInstances[0]
+    expect(typeaheadInstance.innerHTML).to.contain(`id=""`)
+    expect(typeaheadInstance.innerHTML).to.contain(`name=""`)
+  })
+
+  it('can overwrite selectedOption with defaultValue', () => {
+    const id = 'location-picker-id'
+    const name = 'location-picker-name'
+    const options = {
+      fr: 'France',
+      de: 'Germany',
+      gb: 'United Kingdom'
+    }
+    const selectedOption = 'gb'
+    injectSelectToEnhanceIntoDOM(scratch, id, name, options, selectedOption)
+
+    window.AccessibleTypeahead.enhanceSelectElement({
+      defaultValue: 'France',
+      selectElement: document.querySelector('#' + id)
+    })
+
+    const typeaheadInstances = document.querySelectorAll('.typeahead__wrapper')
+    const typeaheadInstance = typeaheadInstances[0]
+    const typeaheadOption = typeaheadInstance.querySelector('.typeahead__option')
+    expect(typeaheadOption.textContent).to.equal('France')
+  })
+
+  it('has all options when typing', (done) => {
+    const id = 'location-picker-id'
+    const name = 'location-picker-name'
+    const options = {
+      fr: 'France',
+      de: 'Germany',
+      gb: 'United Kingdom'
+    }
+    injectSelectToEnhanceIntoDOM(scratch, id, name, options)
+
+    window.AccessibleTypeahead.enhanceSelectElement({
+      selectElement: document.querySelector('#' + id)
+    })
+
+    const typeaheadInstances = document.querySelectorAll('.typeahead__wrapper')
+    const typeaheadInstance = typeaheadInstances[0]
+    const typeaheadInput = typeaheadInstance.querySelector('.typeahead__input')
+    const typeaheadOption = typeaheadInstance.querySelector('.typeahead__option')
+
+    // Using setTimeouts here since changes in values take a while to reflect in lists
+    typeaheadInput.value = 'Fran'
+    expect(typeaheadOption.textContent).to.equal('France')
+    typeaheadInput.value = 'Ger'
+    setTimeout(() => {
+      expect(typeaheadOption.textContent).to.equal('Germany')
+      typeaheadInput.value = 'United'
+      setTimeout(() => {
+        expect(typeaheadOption.textContent).to.equal('United Kingdom')
+        done()
+      }, 250)
+    }, 250)
+  })
+
+  it('onSelect updates original select', (done) => {
+    const id = 'location-picker-id'
+    const name = 'location-picker-name'
+    const options = {
+      fr: 'France',
+      de: 'Germany',
+      gb: 'United Kingdom'
+    }
+    const selectedOption = 'gb'
+    injectSelectToEnhanceIntoDOM(scratch, id, name, options, selectedOption)
+
+    window.AccessibleTypeahead.enhanceSelectElement({
+      defaultValue: 'de',
+      selectElement: document.querySelector('#' + id)
+    })
+
+    const typeaheadInstances = document.querySelectorAll('.typeahead__wrapper')
+    const typeaheadInstance = typeaheadInstances[0]
+    const typeaheadInput = typeaheadInstance.querySelector('.typeahead__input')
+    const typeaheadOption = typeaheadInstance.querySelector('.typeahead__option')
+
+    const originalSelectElement = document.querySelector(`#${id}-select`)
+    // Check the defaultValue has been reflected on the original selectElement
+    expect(originalSelectElement.value).to.equal('de')
+    // Using setTimeouts here since changes in values take a while to reflect in lists
+    typeaheadInput.value = 'United'
+    setTimeout(() => {
+      expect(typeaheadOption.textContent).to.equal('United Kingdom')
+      typeaheadOption.click()
+      expect(originalSelectElement.value).to.equal('gb')
+      done()
+    }, 250)
   })
 })

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -6,7 +6,7 @@ const ENV = process.env.NODE_ENV || 'development'
 
 module.exports = {
   context: path.resolve(__dirname, 'src'),
-  entry: './wrapper.jsx',
+  entry: ['./wrapper.jsx'],
 
   output: {
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
Increased the coverage by testing the Wrapper.jsx entrypoint.

- Tested what's in the README for enhancing select elements
- Setting `opt.defaultValue` now will update the original select elements' selected option
- `opt.defaultValue` will now be set by the original select elements' selected option unless overridden
- Ensure original select elements' name is transfered correctly to the typeahead
- Tested that onSelect updates the original select element

Before:

![image](https://cloud.githubusercontent.com/assets/2445413/24824166/c1d33f0a-1bfe-11e7-8b96-b200e24f70f1.png)

After:

![image](https://cloud.githubusercontent.com/assets/2445413/24824169/c66d1cac-1bfe-11e7-9de4-650de61b75b3.png)

