### PR TITLE
Do not unselect from options when clicking on input

### DIFF
--- a/src/typeahead.jsx
+++ b/src/typeahead.jsx
@@ -209,8 +209,7 @@ export default class Typeahead extends Component {
 
   handleInputFocus (evt) {
     this.setState({
-      focused: -1,
-      selected: -1
+      focused: -1
     })
   }
 
@@ -258,11 +257,11 @@ export default class Typeahead extends Component {
 
   handleUpArrow (evt) {
     evt.preventDefault()
-    const { menuOpen, focused } = this.state
-    const isNotAtTop = focused !== -1
+    const { menuOpen, selected } = this.state
+    const isNotAtTop = selected !== -1
     const allowMoveUp = isNotAtTop && menuOpen
     if (allowMoveUp) {
-      this.handleOptionFocus(focused - 1)
+      this.handleOptionFocus(selected - 1)
     }
   }
 

--- a/test/browser/index.jsx
+++ b/test/browser/index.jsx
@@ -415,12 +415,12 @@ describe('Typeahead', () => {
     })
 
     describe('a printable key', () => {
-      it('on an option, focuses the input', () => {
+      it('on an option, focuses the input, does not change selected', () => {
         typeahead.setState({ menuOpen: true, options: ['France'], focused: 0, selected: 0 })
         typeahead.elementRefs[-1] = 'input element'
         typeahead.handleKeyDown({ target: 'not the input element', keyCode: 65 })
         expect(typeahead.state.focused).to.equal(-1)
-        expect(typeahead.state.selected).to.equal(-1)
+        expect(typeahead.state.selected).to.equal(0)
       })
     })
 


### PR DESCRIPTION
This was left over when the code was transitioned to separate the `focused` state from the `selected` state.