### PR TITLE
Only render hint input if there is something to hint

### DIFF
--- a/src/typeahead.js
+++ b/src/typeahead.js
@@ -355,12 +355,14 @@ export default class Typeahead extends Component {
       const hintValue = (optionBeginsWithQuery && autoselect)
         ? query + selectedOption.substr(query.length)
         : ''
-      return <input
-        className={`${cssNamespace}__hint`}
-        readonly
-        tabindex='-1'
-        value={hintValue}
-      />
+      return hintValue
+        ? <input
+          className={`${cssNamespace}__hint`}
+          readonly
+          tabindex='-1'
+          value={hintValue}
+        />
+        : null
     }
 
     const Input = () => {


### PR DESCRIPTION
This prevents JAWS and NVDA from picking it up on initial page load as a possible form element, which they do in spite of the `tabindex="-1"`.

Closes #56.

Tested:

- [x] iOS VoiceOver
- [x] IE11 JAWS17
- [x] IE11 NVDA