### PR TITLE
Add "style" declaration in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 _(add items here for easier creation of next log entry)_
 
 - Add touchEnd handler for iOS and touch devices, fixes custom suggestions.
+- Add `style` declaration in package.json
 
 ## 0.4.1 - 2017-04-26
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "accessible-typeahead",
   "version": "0.4.1",
   "main": "dist/accessible-typeahead.min.js",
+  "style": "dist/styled.min.css",
   "description": "A typeahead component, built to be accessible.",
   "repository": "alphagov/accessible-typeahead",
   "author": "Theodor Vararu <theodor.vararu@digital.cabinet-office.gov.uk>",


### PR DESCRIPTION
At the Home Office we use a sass compiler that reads from a "style" declaration in package.json files of npm installed modules when compiling css.

By adding a "style" declaration we can include this module's css into our built and compiled code more easily.

Before:

```
@import "accessible-typeahead/dist/styled.min.css"
```

After:


```
@import "accessible-typeahead"
```

It's a pretty minor thing, but smoothes the developer experience as no knowledge of the package internal structure is required to implement.