### PR TITLE
Better errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _(add items here for easier creation of next log entry)_
 
 - Default `defaultValue` when progressively enhancing.
 - Throw an error when `enhanceSelectElement` is called without a `selectElement`.
+- Throw errors when `accessibleTypeahead` is called without `element` or `source`.
 
 ## 0.5.0 - 2017-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 _(add items here for easier creation of next log entry)_
 
 - Default `defaultValue` when progressively enhancing.
+- Throw an error when `enhanceSelectElement` is called without a `selectElement`.
 
 ## 0.5.0 - 2017-05-09
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,14 @@ Or using a script tag:
 And then call the `accessibleTypeahead` function, providing a suggestion engine:
 
 ```js
-function suggest (query, syncResults) {
+function suggest (query, populateResults) {
   const results = [
     'France',
     'Germany',
     'United Kingdom'
   ]
-  syncResults(results.filter(result => result.indexOf(query) !== -1))
+  const filteredResults = results.filter(result => result.indexOf(query) !== -1)
+  populateResults(filteredResults)
 }
 
 accessibleTypeahead({
@@ -81,25 +82,21 @@ The container element in which the typeahead will be rendered in.
 
 Type: `PropTypes.func`
 
-Arguments: `query: string, syncResults: Function`
+Arguments: `query: string, populateResults: Function`
 
-Similar to the [`source` argument for typeahead.js](https://github.com/corejavascript/typeahead.js/blob/47d46b40cb834d8285ac9328c4b436e5eccf7197/doc/jquery_typeahead.md#datasets), a backing data source for suggestions. `query` is what gets typed into the input field, which will callback to `syncResults` synchronously with the array of string results to display in the menu.
+Similar to the [`source` argument for typeahead.js](https://github.com/corejavascript/typeahead.js/blob/47d46b40cb834d8285ac9328c4b436e5eccf7197/doc/jquery_typeahead.md#datasets), a backing data source for suggestions. `query` is what gets typed into the input field, which will callback to `populateResults` synchronously with the array of string results to display in the menu.
 
 An example of a simple suggestion engine:
 
 ```js
-function suggest (query, syncResults) {
-  var results = [
+function suggest (query, populateResults) {
+  const results = [
     'France',
     'Germany',
     'United Kingdom'
   ]
-  syncResults(query
-    ? results.filter(function (result) {
-        return result.toLowerCase().indexOf(query.toLowerCase()) !== -1
-      })
-    : []
-  )
+  const filteredResults = results.filter(result => result.indexOf(query) !== -1)
+  populateResults(filteredResults)
 }
 ```
 

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -2,6 +2,12 @@ import { h, render } from 'preact' /** @jsx h */
 import Typeahead from './typeahead'
 
 function accessibleTypeahead (opts) {
+  if (!opts.element) {
+    throw new Error('element is not defined')
+  }
+  if (!opts.source) {
+    throw new Error('source is not defined')
+  }
   render(<Typeahead {...opts} />, opts.element)
 }
 
@@ -13,6 +19,9 @@ const createSimpleEngine = results => (query, syncResults) => {
 }
 
 accessibleTypeahead.enhanceSelectElement = (opts) => {
+  if (!opts.selectElement) {
+    throw new Error('selectElement is not defined')
+  }
   // Set defaults.
   if (!opts.source) {
     const availableOptions = Array.prototype.map.call(opts.selectElement.options, o => o.innerHTML)

--- a/test/functional/wrapper.js
+++ b/test/functional/wrapper.js
@@ -39,6 +39,33 @@ describe('Wrapper', () => {
     scratch = null
   })
 
+  it('throws an error when called on nonexistent element', () => {
+    expect(
+      accessibleTypeahead.bind(null, {
+        element: document.querySelector('#nothing'),
+        source: () => {}
+      })
+    ).to.throw('element is not defined')
+  })
+
+  it('throws an error when called on nonexistent source', () => {
+    const id = 'location-picker-id'
+    const name = 'location-picker-name'
+    const options = {
+      fr: 'France',
+      de: 'Germany',
+      gb: 'United Kingdom'
+    }
+    const selectedOption = 'gb'
+    injectSelectToEnhanceIntoDOM(scratch, id, name, options, selectedOption)
+
+    expect(
+      accessibleTypeahead.bind(null, {
+        element: document.querySelector('#' + id)
+      })
+    ).to.throw('source is not defined')
+  })
+
   it('throws an error when called on nonexistent selectElement', () => {
     expect(
       accessibleTypeahead.enhanceSelectElement.bind(null, {

--- a/test/functional/wrapper.js
+++ b/test/functional/wrapper.js
@@ -39,6 +39,14 @@ describe('Wrapper', () => {
     scratch = null
   })
 
+  it('throws an error when called on nonexistent selectElement', () => {
+    expect(
+      accessibleTypeahead.enhanceSelectElement.bind(null, {
+        selectElement: document.querySelector('#nothing')
+      })
+    ).to.throw('selectElement is not defined')
+  })
+
   it('can enhance a select element', () => {
     const id = 'location-picker-id'
     const name = 'location-picker-name'


### PR DESCRIPTION
Throw more errors when required arguments are not passed into `accessibleTypeahead` or `enhanceSelectElement`.

Slightly update the README based on feedback from @nickcolley.